### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,12 @@
 {
   "name": "Import images in Supervisely format",
   "type": "app",
-  "categories": ["import", "images"],
+  "categories": [
+    "import",
+    "images"
+  ],
   "description": "Images with corresponding annotations",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "icon": "https://i.imgur.com/lmbzQd0.png",
@@ -14,6 +17,11 @@
   "instance_version": "6.15.60",
   "context_menu": {
     "context_category": "Import",
-    "target": ["files_folder", "files_file", "agent_folder", "agent_file"]
+    "target": [
+      "files_folder",
+      "files_file",
+      "agent_folder",
+      "agent_file"
+    ]
   }
 }

--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
   "icon_cover": true,
   "headless": true,
   "min_agent_version": "6.7.4",
-  "min_instance_version": "6.15.40",
+  "instance_version": "6.15.60",
   "context_menu": {
     "context_category": "Import",
     "target": ["files_folder", "files_file", "agent_folder", "agent_file"]

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["import", "images"],
   "description": "Images with corresponding annotations",
-  "docker_image": "supervisely/import-export:6.73.534",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "icon": "https://i.imgur.com/lmbzQd0.png",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.534
+supervisely==6.73.564

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/supervisely/supervisely.git@tag-value-date
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-git+https://github.com/supervisely/supervisely.git@tag-value-date
-


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
